### PR TITLE
Update README files with Kaggle model links and file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ torch.save(model.state_dict(), 'saved_models/my_sst_model.pth')
 
 ### 3. Use Enhanced Gradio Interface (Complete Stage1 + Stage2 Training)
 
+**Gradio UI Demo Video**: Coming soon
+
 #### **Getting Started with Jupyter Notebook Tutorial**
 
 For a step-by-step guide, see:
@@ -523,7 +525,11 @@ for signal_idx in range(num_signals):
 - ✅ **Real-world sensor data**: Demonstrates effectiveness on production equipment measurements
 - ✅ **Efficient training**: Both stages train quickly on standard hardware
 
-**Trained Models**: [Available on Kaggle Models](https://www.kaggle.com/models) (coming soon)
+**Trained Models**: [Available on Kaggle Models](https://www.kaggle.com/models/tianffan/industrial-digital-twin-by-transformer)
+
+**Model File Locations**:
+- **Stage1 Models**: Three files (`.pth`, `_config.json`, `_scaler.pkl`) are located in `saved_models/`
+- **Stage2 Models**: Located in `saved_models/stage2_boost/`
 
 **Note on Benchmarks**:
 These results are provided as reference examples on specific datasets. This project prioritizes **practical applicability and ease of deployment** over competitive benchmark scores. Performance will vary based on your specific industrial application, sensor characteristics, and data quality. We encourage users to evaluate the framework on their own use cases.

--- a/README_CN.md
+++ b/README_CN.md
@@ -344,6 +344,8 @@ torch.save(model.state_dict(), 'saved_models/my_sst_model.pth')
 
 ### 3. 使用增强型 Gradio 界面（完整 Stage1 + Stage2 训练）
 
+**Gradio UI 演示视频**：即将推出
+
 #### **Jupyter Notebook 入门教程**
 
 有关分步指南，请参阅：
@@ -524,7 +526,11 @@ for signal_idx in range(num_signals):
 - ✅ **真实传感器数据**：在生产设备测量数据上展示有效性
 - ✅ **高效训练**：两个阶段都能在标准硬件上快速训练
 
-**训练模型**：[Kaggle Models 提供](https://www.kaggle.com/models)（即将上线）
+**训练模型**：[Kaggle Models 提供](https://www.kaggle.com/models/tianffan/industrial-digital-twin-by-transformer)
+
+**模型文件位置**：
+- **Stage1 模型**：三个文件（`.pth`、`_config.json`、`_scaler.pkl`）位于 `saved_models/` 目录下
+- **Stage2 模型**：位于 `saved_models/stage2_boost/` 目录下
 
 **关于基准测试的说明**：
 这些结果作为特定数据集上的参考示例提供。本项目优先考虑**实用性和易部署性**，而非竞争性基准分数。性能将根据您的具体工业应用、传感器特性和数据质量而变化。我们鼓励用户在自己的应用场景中评估本框架。


### PR DESCRIPTION
- Added Kaggle model link: https://www.kaggle.com/models/tianffan/industrial-digital-twin-by-transformer
- Added model file location information:
  * Stage1 models (.pth, _config.json, _scaler.pkl) in saved_models/
  * Stage2 models in saved_models/stage2_boost/
- Added note about Gradio UI demo video (coming soon) in both English and Chinese versions